### PR TITLE
Adjust spacing on Links page

### DIFF
--- a/links/index.html
+++ b/links/index.html
@@ -61,7 +61,7 @@
     .links-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-      gap: 1.5rem;
+        gap: 0.5rem;
       justify-items: center;
       align-items: center;
     }
@@ -99,7 +99,7 @@
         padding: 1rem;
       }
       .links-grid {
-        gap: 1rem;
+        gap: 0.25rem;
         grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
       }
       .link-icon {


### PR DESCRIPTION
## Summary
- tighten spacing between link icons on Links page

## Testing
- `git diff --color --unified=5 links/index.html`

------
https://chatgpt.com/codex/tasks/task_e_688a00ebb7ac832d89ecda184e5ca799